### PR TITLE
Relax dependency versions because this is a library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,19 +3,20 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.dependencies]
+once_cell = "^1"
+regex = "^1"
+semver = "^1"
+serde = "^1"
+serde_json = "^1"
+thiserror = "^1"
+
 clean-path = "0.2.1"
 indexmap = "2.2.5"
 miette = "7.0.0"
-once_cell = "1.19.0"
 petgraph = { version = "0.6.4", default-features = false, features = [
 	"serde-1",
 ] }
-regex = "1.10.3"
 rustc-hash = "1.1.0"
-semver = "1.0.22"
-serde = "1.0.197"
-serde_json = "1.0.114"
 serde_yaml = "0.9.32"
 starbase_sandbox = "0.4.0"
 starbase_utils = { version = "0.5.0", default-features = false }
-thiserror = "1.0.57"


### PR DESCRIPTION
Getting things like 

```
error: failed to select a version for `semver`.
    ... required by package `nodejs_package_json v0.1.1`
    ... which satisfies dependency `nodejs_package_json = "^0.1.1"` of package `oxc_resolver v1.5.4 (https://github.com/oxc-project/oxc-resolver#c859cdcf)`
    ... which satisfies git dependency `oxc_resolver` of package `rspack_core v0.1.0 (/Users/bytedance/github/rspack/crates/rspack_core)`
    ... which satisfies path dependency `rspack_core` (locked to 0.1.0) of package `rspack v0.1.0 (/Users/bytedance/github/rspack/crates/rspack)`
versions that meet the requirements `^1.0.22` are: 1.0.22

all possible versions conflict with previously selected packages.

  previously selected package `semver v1.0.20`
    ... which satisfies dependency `semver = "^1"` (locked to 1.0.20) of package `napi-derive-backend v1.0.62`
    ... which satisfies dependency `napi-derive-backend = "^1.0.62"` (locked to 1.0.62) of package `napi-derive v2.16.0`
    ... which satisfies dependency `napi-derive = "=2.16.0"` (locked to 2.16.0) of package `rspack_node v0.1.0 (/Users/bytedance/github/rspack/crates/node_binding)`

failed to select a version for `semver` which could resolve this conflict
```

I think it's a common practice to pin to major versions, but I'm not sure as I haven't worked on enough libraries for other people to use 😅 