### PR TITLE
fix: Better serde handling for tsconfig.

### DIFF
--- a/crates/package-json/src/package_json.rs
+++ b/crates/package-json/src/package_json.rs
@@ -21,7 +21,10 @@ pub type ScriptsMap = FxIndexMap<String, String>;
 #[serde(default, rename_all = "camelCase")]
 pub struct PackageJson {
     pub name: Option<String>,
+    #[cfg(feature = "protocols")]
     pub version: Option<Version>,
+    #[cfg(not(feature = "protocols"))]
+    pub version: Option<String>,
     pub scripts: Option<ScriptsMap>,
 
     // Entry points

--- a/crates/tsconfig-json/tests/compiler_options_test.rs
+++ b/crates/tsconfig-json/tests/compiler_options_test.rs
@@ -11,6 +11,11 @@ fn handles_jsx() {
     let options: CompilerOptions = serde_json::from_str(r#"{ "jsx": "react-jsxdev" }"#).unwrap();
 
     assert_eq!(options.jsx.unwrap(), JsxField::ReactJsxdev);
+
+    assert_eq!(
+        serde_json::to_string(&JsxField::ReactJsxdev).unwrap(),
+        "\"react-jsxdev\""
+    );
 }
 
 #[test]
@@ -22,6 +27,11 @@ fn handles_module() {
     let options: CompilerOptions = serde_json::from_str(r#"{ "module": "Es2015" }"#).unwrap();
 
     assert_eq!(options.module.unwrap(), ModuleField::Es2015);
+
+    assert_eq!(
+        serde_json::to_string(&ModuleField::Es2015).unwrap(),
+        "\"es2015\""
+    );
 }
 
 #[test]
@@ -41,6 +51,11 @@ fn handles_module_resolution() {
         options.module_resolution.unwrap(),
         ModuleResolutionField::NodeNext
     );
+
+    assert_eq!(
+        serde_json::to_string(&ModuleResolutionField::NodeNext).unwrap(),
+        "\"nodenext\""
+    );
 }
 
 #[test]
@@ -52,4 +67,9 @@ fn handles_target() {
     let options: CompilerOptions = serde_json::from_str(r#"{ "target": "EsNext" }"#).unwrap();
 
     assert_eq!(options.target.unwrap(), TargetField::EsNext);
+
+    assert_eq!(
+        serde_json::to_string(&TargetField::EsNext).unwrap(),
+        "\"esnext\""
+    );
 }


### PR DESCRIPTION
I noticed serializing was outputting the wrong value format, so I used `rename_all`, but then it breaks deserializing since it then requires the input to be in that format. To fix deserializing, I had to implement it custom for each enum...